### PR TITLE
Fix overflow possibility triggered by pathological (e.g., clipping) audio

### DIFF
--- a/main.c
+++ b/main.c
@@ -338,7 +338,7 @@ int main (argc, argv) int argc; char **argv;
     write_pcm_wav_header (outfile, 0, WaveHeader.NumChannels, 2, scaled_rate);
 
     short *inbuffer = malloc (BUFFER_SAMPLES * WaveHeader.BlockAlign);
-    short *outbuffer = malloc ((BUFFER_SAMPLES * 2 + max_period * 3) * WaveHeader.BlockAlign);
+    short *outbuffer = malloc ((BUFFER_SAMPLES * 2 + max_period * 4) * WaveHeader.BlockAlign);
 
     while (1) {
         int samples_read = fread (inbuffer, WaveHeader.BlockAlign,

--- a/main.c
+++ b/main.c
@@ -402,13 +402,13 @@ static int write_pcm_wav_header (FILE *outfile, size_t num_samples, int num_chan
     wavhdr.BlockAlign = bytes_per_sample * num_channels;
     wavhdr.BitsPerSample = bytes_per_sample * 8;
 
-    strncpy (riffhdr.ckID, "RIFF", sizeof (riffhdr.ckID));
-    strncpy (riffhdr.formType, "WAVE", sizeof (riffhdr.formType));
+    memcpy (riffhdr.ckID, "RIFF", sizeof (riffhdr.ckID));
+    memcpy (riffhdr.formType, "WAVE", sizeof (riffhdr.formType));
     riffhdr.ckSize = sizeof (riffhdr) + wavhdrsize + sizeof (datahdr) + total_data_bytes;
-    strncpy (fmthdr.ckID, "fmt ", sizeof (fmthdr.ckID));
+    memcpy (fmthdr.ckID, "fmt ", sizeof (fmthdr.ckID));
     fmthdr.ckSize = wavhdrsize;
 
-    strncpy (datahdr.ckID, "data", sizeof (datahdr.ckID));
+    memcpy (datahdr.ckID, "data", sizeof (datahdr.ckID));
     datahdr.ckSize = total_data_bytes;
 
     return fwrite (&riffhdr, sizeof (riffhdr), 1, outfile) &&


### PR DESCRIPTION
@hayguen ,this is what I came up with for a fix to the overflow. The extra time to calculate the sum is negligible compared to to the other times, and in the stereo and "fast" case we're looping through all the samples anyway so it's almost free. This also allows the best possible precision for the actual audio (usually much better than before). And I included the check for silence (which also provides a great speedup for audio that contains runs of silence).

Assuming I didn't miss anything I'd like to go with this first as it seems like your other changes are (at least mostly) cosmetic. I have some myself and some other improvements, so I'll work on those afterward.

Thanks!